### PR TITLE
ci(build-and-test): add build and test github action workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,47 @@
+name: Build and test
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 18.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          cache: npm
+          node-version: ${{ matrix.node-version }}
+
+      - name: install
+        run: |
+          npm ci
+
+      - name: static checks
+        run: |
+          npm run lint
+
+      - name: build
+        run: |
+          npm run build
+
+      - name: test
+        run: |
+          npm run test


### PR DESCRIPTION
Adds a GitHub Action workflow to build and test any changes. Borrowed the workflow of the same name from `compromise` and tweaked it to suit this repo!

This PR also:

-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
-   Declares the minimum permissions for CI workflows to run at the job level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Enables `concurrency` in `ci.yml`; see [related docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency), this allows a subsequently queued workflow run to interrupt previous runs in PRs