### PR TITLE
ci: drop eol node versions from test matrix; add node 16 and 20

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,12 @@
 {
   "root": true,
   "env": {
-    "es6": true,
+    "es2021": true,
     "browser": true,
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2021,
     "sourceType": "module",
     "ecmaFeatures": {}
   },

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 18.x]
+        node-version: [16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: install
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: static checks
         run: |

--- a/scratch.js
+++ b/scratch.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const { detect, replace } = require('./src')
 const fs = require('fs')
 

--- a/scripts/parse-config/index.js
+++ b/scripts/parse-config/index.js
@@ -7,25 +7,25 @@ const {resolve} = require('path')
 let parsed = []
 
 const parse = (char) => {
-    const codeEscaped = char.code.replace(/^U\+/, '\\u')
-    const codeNumber = char.code.replace('U+', '')
-    const actualUnicodeChar = String.fromCodePoint(`0x${codeNumber}`)
-    const htmlEntity = codes.find(code => code.unicode === char.code)
-    return {
-        ...htmlEntity,
-        ...char,
-        actualUnicodeChar,
-        codeEscaped,
-        url: `https://www.compart.com/en/unicode/${char.code}`
-    }
+  const codeEscaped = char.code.replace(/^U\+/, '\\u')
+  const codeNumber = char.code.replace('U+', '')
+  const actualUnicodeChar = String.fromCodePoint(`0x${codeNumber}`)
+  const htmlEntity = codes.find(code => code.unicode === char.code)
+  return {
+    ...htmlEntity,
+    ...char,
+    actualUnicodeChar,
+    codeEscaped,
+    url: `https://www.compart.com/en/unicode/${char.code}`
+  }
 }
 
 const save = (obj) => {
-    fs.writeFile(resolve(`${__dirname}/../../data/characters.json`), JSON.stringify(obj, null, 2), (err) => {
-        if (err) throw err;
-        console.log('The file has been saved!');
-        console.log(parsed)
-    })
+  fs.writeFile(resolve(`${__dirname}/../../data/characters.json`), JSON.stringify(obj, null, 2), (err) => {
+    if (err) throw err
+    console.log('The file has been saved!')
+    console.log(parsed)
+  })
 }
 
 


### PR DESCRIPTION
This PR:

- Adds node 16 and 20 to the CI test matrix
- Drops EOL node versions from CI test matrix
- Adds `--ignore-scripts` to `npm ci` call in CI to reduce the risk of arbitrary command execution
- Bumps ECMA version in ESLint from ES2015 to ES2021 to support object spread used in `scripts/parse-config/index.js`, which was introduced in ES2018

Babel transcompiles the code back into syntax old versions support during the rollup/build stage anyway.