### PR TITLE
perf: add missing `'use strict'` directives

### DIFF
--- a/bin/detect-file.js
+++ b/bin/detect-file.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('fs')
 const { detect } = require('../src/index')
 const { blue, yellow, dim, italic, red } = require('colorette')

--- a/bin/getFiles.js
+++ b/bin/getFiles.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const glob = require('glob')
 const fs = require('fs')
 const path = require('path')

--- a/bin/out-of-character.js
+++ b/bin/out-of-character.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict'
+
 const fs = require('fs')
 const { dim, blue } = require('colorette')
 const detectFile = require('./detect-file')

--- a/scratch.js
+++ b/scratch.js
@@ -1,4 +1,7 @@
 /* eslint-disable no-unused-vars */
+
+'use strict'
+
 const { detect, replace } = require('./src')
 const fs = require('fs')
 

--- a/scripts/parse-config/index.js
+++ b/scripts/parse-config/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // @todo turn this into modules and promisify + tidy
 const codes = require('../../data/codes.json')
 const config = require('../../data/characters-raw.json')

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const findAll = require('./match')
 
 module.exports = {

--- a/src/isEmoji.js
+++ b/src/isEmoji.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const isVariationSelector = (num) => num >= 65024 && num <= 65039
 const isHighSurrogate = (num) => num >= 55296 && num <= 56319
 const isLowSurrogate = (num) => num >= 56320 && num <= 57343

--- a/src/match.js
+++ b/src/match.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const data = require('../data/characters.json')
 const isEmoji = require('./isEmoji')
 

--- a/tests/bin.test.js
+++ b/tests/bin.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const test = require('tape')
 const { exec } = require('shelljs')
 const fs = require('fs')

--- a/tests/detect.test.js
+++ b/tests/detect.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const test = require('tape')
 const { detect } = require('../src')
 

--- a/tests/emoji.test.js
+++ b/tests/emoji.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const test = require('tape')
 const { detect } = require('../src')
 

--- a/tests/replace.test.js
+++ b/tests/replace.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const test = require('tape')
 const { replace } = require('../src')
 const spaces = [


### PR DESCRIPTION
This PR adds missing `'use strict'` directives to the cjs files in this repo. Strict mode can improve performance by eliminating some JavaScript features that hinder optimizations. It also helps avoid subtle bugs by enforcing more consistent scoping and variable declarations.

The [MDN article on strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) alludes to it, but the V8 JS engine used by Node will use more optimised execution paths when strict mode is enabled. See [related Stack Overflow discussion](https://stackoverflow.com/questions/38411552/why-use-strict-improves-performance-10x-in-this-example) for an example.