### PR TITLE
perf(src/match): use regex unicode `u` flag

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -9,15 +9,10 @@ const byCode = data.reduce((h, obj) => {
   return h
 }, {})
 
-// Chars to create our regex with
-const unicodePrefixRegex = /^U\+/
 const codes = data
   .filter((obj) => obj.replaceWith !== undefined)
-  .map((obj) => {
-    // Convert "U+XXXX" to "\\uXXXX" for RegExp
-    return obj.code.replace(unicodePrefixRegex, '\\u')
-  })
-const codeRegex = new RegExp(`(${codes.join('|')})`, 'g')
+  .map((obj) => obj.actualUnicodeChar)
+const codeRegex = new RegExp(`(${codes.join('|')})`, 'gu')
 
 /**
  * @description Finds all invisible characters in the given text.
@@ -44,8 +39,8 @@ const findAll = function (text) {
       }
 
       matches.push({
-        name: found.name,
         code: found.code,
+        name: found.name,
         offset: offset,
         replacement: found.replaceWith || '',
       })


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode.
This means we can use unicode characters in the regex directly, rather than having to use escaped codes.
In turn, we can get rid of the replace and regex combination.