### PR TITLE
perf(index): use `for` loop over `for...of` loop

### DIFF
--- a/scripts/parse-config/index.js
+++ b/scripts/parse-config/index.js
@@ -20,16 +20,18 @@ const parse = function (char) {
     actualUnicodeChar,
     codeEscaped,
     url: `https://www.compart.com/en/unicode/${char.code}`
-  };
-
-  // Return the object with keys sorted alphabetically
-  const sortedKeys = Object.keys(combinedObject).sort();
-  const sortedObject = {};
-  for (const key of sortedKeys) {
-    sortedObject[key] = combinedObject[key];
   }
 
-  return sortedObject; 
+  // Return the object with keys sorted alphabetically
+  const sortedKeys = Object.keys(combinedObject).sort()
+  const sortedObject = {}
+  const sortedKeysLength = sortedKeys.length
+  for (let i = 0; i < sortedKeysLength; i+= 1) {
+    const key = sortedKeys[i]
+    sortedObject[key] = combinedObject[key]
+  }
+
+  return sortedObject
 }
 
 const save = function (obj) {

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,9 @@ module.exports = {
     let result = ''
     let lastIndex = 0
 
-    for (const match of matches) {
+    const matchesLength = matches.length
+    for (let i = 0; i < matchesLength; i+= 1) {
+      const match = matches[i]
       result += text.slice(lastIndex, match.offset)
       result += match.replacement
       lastIndex = match.offset + 1


### PR DESCRIPTION
`for...of` [has an iterator overhead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#description).

A traditional loop is faster because there are no intermediate objects created or function calls during iteration.
With the length being cached, there are no property lookups either.

See https://github.com/kibertoad/nodejs-benchmark-tournament for supporting benchmarking.