### PR TITLE
chore: remove .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,0 @@
-- id: out-of-character
-  name: Out of Character
-  entry: out-of-character
-  language: node


### PR DESCRIPTION
This is for [Python's pre-commit](https://pre-commit.com). This isn't a Python project.