### PR TITLE
ci: use tags for immutable github actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -52,12 +52,12 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@v4
         with:
           cache: npm
           check-latest: true
@@ -90,12 +90,12 @@ jobs:
         contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@v4
         with:
           cache: npm
           check-latest: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,18 +38,18 @@ jobs:
       security-events: write
     steps:
       - name: Check out repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       # Initialises the CodeQL tools for scanning
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
+        uses: github/codeql-action/init@v3
         with:
           config-file: ./.github/codeql-config.yml
           languages: ${{ matrix.languages }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Most first-party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes, but this is not available for third-party actions yet.