### PR TITLE
Strip explicit bidirectional formatting characters

### DIFF
--- a/data/characters-raw.json
+++ b/data/characters-raw.json
@@ -538,5 +538,77 @@
         "name": "MUSICAL SYMBOL END PHRASE",
         "replaceWith": "",
         "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+202A",
+        "escapeChar": "",
+        "name": "LEFT-TO-RIGHT EMBEDDING",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+202B",
+        "escapeChar": "",
+        "name": "RIGHT-TO-LEFT EMBEDDING",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+202C",
+        "escapeChar": "",
+        "name": "POP DIRECTIONAL FORMATTING",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+202D",
+        "escapeChar": "",
+        "name": "LEFT-TO-RIGHT OVERRIDE",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+202E",
+        "escapeChar": "",
+        "name": "RIGHT-TO-LEFT OVERRIDE",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+2066",
+        "escapeChar": "",
+        "name": "LEFT-TO-RIGHT ISOLATE",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+2067",
+        "escapeChar": "",
+        "name": "RIGHT-TO-LEFT ISOLATE",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+2068",
+        "escapeChar": "",
+        "name": "FIRST STRONG ISOLATE",
+        "replaceWith": "",
+        "type": "Invisible"
+    },
+    {
+        "aka": "",
+        "code": "U+2069",
+        "escapeChar": "",
+        "name": "POP DIRECTIONAL ISOLATE",
+        "replaceWith": "",
+        "type": "Invisible"
     }
 ]

--- a/data/characters.json
+++ b/data/characters.json
@@ -774,5 +774,104 @@
     "replaceWith": "",
     "type": "Invisible",
     "url": "https://www.compart.com/en/unicode/U+1D17A"
+  },
+  {
+    "actualUnicodeChar": "‪",
+    "aka": "",
+    "code": "U+202A",
+    "codeEscaped": "\\u202A",
+    "escapeChar": "",
+    "name": "LEFT-TO-RIGHT EMBEDDING",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+202A"
+  },
+  {
+    "actualUnicodeChar": "‫",
+    "aka": "",
+    "code": "U+202B",
+    "codeEscaped": "\\u202B",
+    "escapeChar": "",
+    "name": "RIGHT-TO-LEFT EMBEDDING",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+202B"
+  },
+  {
+    "actualUnicodeChar": "‬",
+    "aka": "",
+    "code": "U+202C",
+    "codeEscaped": "\\u202C",
+    "escapeChar": "",
+    "name": "POP DIRECTIONAL FORMATTING",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+202C"
+  },
+  {
+    "actualUnicodeChar": "‭",
+    "aka": "",
+    "code": "U+202D",
+    "codeEscaped": "\\u202D",
+    "escapeChar": "",
+    "name": "LEFT-TO-RIGHT OVERRIDE",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+202D"
+  },
+  {
+    "actualUnicodeChar": "‮",
+    "aka": "",
+    "code": "U+202E",
+    "codeEscaped": "\\u202E",
+    "escapeChar": "",
+    "name": "RIGHT-TO-LEFT OVERRIDE",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+202E"
+  },
+  {
+    "actualUnicodeChar": "⁦",
+    "aka": "",
+    "code": "U+2066",
+    "codeEscaped": "\\u2066",
+    "escapeChar": "",
+    "name": "LEFT-TO-RIGHT ISOLATE",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+2066"
+  },
+  {
+    "actualUnicodeChar": "⁧",
+    "aka": "",
+    "code": "U+2067",
+    "codeEscaped": "\\u2067",
+    "escapeChar": "",
+    "name": "RIGHT-TO-LEFT ISOLATE",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+2067"
+  },
+  {
+    "actualUnicodeChar": "⁨",
+    "aka": "",
+    "code": "U+2068",
+    "codeEscaped": "\\u2068",
+    "escapeChar": "",
+    "name": "FIRST STRONG ISOLATE",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+2068"
+  },
+  {
+    "actualUnicodeChar": "⁩",
+    "aka": "",
+    "code": "U+2069",
+    "codeEscaped": "\\u2069",
+    "escapeChar": "",
+    "name": "POP DIRECTIONAL ISOLATE",
+    "replaceWith": "",
+    "type": "Invisible",
+    "url": "https://www.compart.com/en/unicode/U+2069"
   }
 ]

--- a/tests/bidi.test.js
+++ b/tests/bidi.test.js
@@ -1,0 +1,45 @@
+import test from 'tape'
+import { detect, replace } from '../src/index.js'
+
+// Explicit bidirectional formatting controls (Bidi_Control=Yes). The implicit
+// marks U+200E/U+200F/U+061C were already handled; these are the embedding,
+// override and isolate controls used by the Trojan Source attack
+// (CVE-2021-42574). Code points are spelled out so the (invisible) characters
+// are reviewable in source.
+const bidi = [
+  [0x202a, 'LEFT-TO-RIGHT EMBEDDING'],
+  [0x202b, 'RIGHT-TO-LEFT EMBEDDING'],
+  [0x202c, 'POP DIRECTIONAL FORMATTING'],
+  [0x202d, 'LEFT-TO-RIGHT OVERRIDE'],
+  [0x202e, 'RIGHT-TO-LEFT OVERRIDE'],
+  [0x2066, 'LEFT-TO-RIGHT ISOLATE'],
+  [0x2067, 'RIGHT-TO-LEFT ISOLATE'],
+  [0x2068, 'FIRST STRONG ISOLATE'],
+  [0x2069, 'POP DIRECTIONAL ISOLATE'],
+]
+
+test('remove bidirectional formatting characters', function (t) {
+  bidi.forEach(([cp, name]) => {
+    const ch = String.fromCodePoint(cp)
+    t.equal(replace('before' + ch + 'after'), 'beforeafter', name + ' is removed')
+  })
+  t.end()
+})
+
+test('detect bidirectional formatting characters', function (t) {
+  bidi.forEach(([cp, name]) => {
+    const ch = String.fromCodePoint(cp)
+    const found = detect('before' + ch + 'after')
+    t.equal(found && found.length, 1, name + ' is detected')
+    t.equal(found[0].name, name, name + ' has the expected name')
+  })
+  t.end()
+})
+
+test('strip a Trojan Source style override sequence', function (t) {
+  // RIGHT-TO-LEFT OVERRIDE ... POP DIRECTIONAL FORMATTING reorders the visible text
+  const rlo = String.fromCodePoint(0x202e)
+  const pdf = String.fromCodePoint(0x202c)
+  t.equal(replace('access' + rlo + 'level' + pdf), 'accesslevel', 'override pair removed')
+  t.end()
+})


### PR DESCRIPTION
`replace` and `detect` already remove the implicit bidi marks (`U+200E` LEFT-TO-RIGHT MARK, `U+200F` RIGHT-TO-LEFT MARK, `U+061C` ARABIC LETTER MARK), but not the explicit bidirectional formatting controls:

- `U+202A`–`U+202E`: the left/right embeddings, the two overrides, and pop directional formatting
- `U+2066`–`U+2069`: the left/right/first-strong isolates and pop directional isolate

These have no visible glyph, so they fit the "invisible characters" the library targets, and they share the `Bidi_Control` property with the three marks that are already stripped. They are also the characters used in the Trojan Source attack (CVE-2021-42574): a `RIGHT-TO-LEFT OVERRIDE` or isolate can reorder how the surrounding text renders while leaving the underlying bytes unchanged, which is exactly the kind of hidden character this tool is meant to catch.

The nine code points are added to `data/characters-raw.json` and to the generated `data/characters.json`, handled the same way as `U+200E`/`U+200F`/`U+061C` (`replaceWith: ""`). `tests/bidi.test.js` covers removal and detection of each one.
